### PR TITLE
検査実施人数のダウンロード処理を追加した。

### DIFF
--- a/app/Counts.php
+++ b/app/Counts.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App;
+
+use Illuminate\Support\Collection;
+
+abstract class Counts 
+{
+    protected $OriginalRec ;
+    protected $DstRec ;
+
+    public function __construct()
+    {
+        $this->OriginalRec = new Collection();
+    }
+
+    public function push($rec)
+    {
+        $this->OriginalRec->push($rec);
+    }
+
+    public function all()
+    {
+        return $this->OriginalRec->all();
+    }
+
+    abstract public function convert();
+    abstract public function headings();
+
+    /**
+     * 変換後のデータをCSV形式で出力
+     */
+    public function create_file($filename)
+    {
+        $this->convert();
+        $fp = fopen($filename, 'w');
+        if($fp == FALSE) {
+            throw new Exception('Error: Failed to open file (' . $filename . ')');
+        }
+
+        $length = fputcsv($fp, $this->headings());
+        foreach($this->DstRec->toArray() as $rec) 
+        {
+            $length += fputcsv($fp, $rec);
+        }
+
+        fclose($fp);
+
+        return $length;
+    }
+}

--- a/app/CountsInspected.php
+++ b/app/CountsInspected.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App;
+use Illuminate\Support\Collection;
+use App\Counts;
+
+class CountsInspected extends Counts
+{
+    /**
+     * オリジナルレコードを元に、変換後のデータを作成する。
+     */
+    public function convert()
+    {
+        $this->DstRec =  new Collection();
+
+        foreach($this->OriginalRec as $rec)
+        {
+            $dst_rec = array();
+
+            //  Byte Order Markを削除
+            if(strcmp(preg_replace('/^\xEF\xBB\xBF/', '', $rec[0]), "年月日") == 0) 
+            {
+                continue;
+            }
+            //  年月日
+            array_push($dst_rec, $rec[0]);
+            // 　自治体コード(富山県固定)
+            array_push($dst_rec, "16000");
+            //  都道府県名(富山県固定)
+            array_push($dst_rec, "富山県");
+            //  市区町村名(県発表のため、空白)
+            array_push($dst_rec, "");
+            //  検査実施人数
+            array_push($dst_rec, $rec[1]);
+            //  備考
+            array_push($dst_rec, $rec[7]);
+
+            $this->DstRec->push($dst_rec);
+        }
+    }
+    
+	public function headings():array
+	{
+		return [
+            pack('C*',0xEF,0xBB,0xBF).'結果判明_年月日', 
+            '全国地方公共団体コード',
+            '都道府県名',
+            '市区町村名',
+            '検査実施_人数',
+            '備考',
+        ];
+	}
+
+}

--- a/app/Http/Controllers/OpendataController.php
+++ b/app/Http/Controllers/OpendataController.php
@@ -36,6 +36,7 @@ class OpendataController extends Controller
         }
 
         fclose($fp);
+        unlink($filename);
 
         //  出力用のCSV作成
         $outfilename = tempnam ('./', $this->LocalCSV);

--- a/app/Http/Controllers/ToyamaCountsController.php
+++ b/app/Http/Controllers/ToyamaCountsController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\CountsInspected;
+
+
+class ToyamaCountsController extends Controller
+{
+    protected $RemoteCSV = '16000_toyama_covid19_test_people.csv';
+    protected $LocalCSV = 'toyama_counts.';
+    protected $OpendataPath = 'http://opendata.pref.toyama.jp/files/covid19/20200403/toyama_counts.csv';
+
+    /**
+     * 陽性患者属性以外を富山県オープンデータサイトから取得し、
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し
+     * ダウンロードする。
+     */
+    public function get_inspected()
+    {
+        //  県のオープンデータを取得し、一旦、保存する
+        $csv = file_get_contents($this->OpendataPath); //ファイルの保存先
+        $filename = tempnam ('./', $this->LocalCSV);
+        file_put_contents($filename,$csv);
+
+        //  CSVファイルを読み込み
+        $fp = fopen($filename, 'r');
+        if($fp == FALSE) {
+            throw new Exception('Error: Failed to open file (' . $filename . ')');
+        }
+
+        $CountsInspected = new CountsInspected();
+        while (($rec = fgetcsv($fp)) != FALSE) {
+            $CountsInspected->push($rec);
+        }
+
+        fclose($fp);
+        unlink($filename);
+
+        //  出力用のCSV作成
+        $outfilename = tempnam ('./', $this->LocalCSV);
+        $length = $CountsInspected->create_file($outfilename);
+
+        //  ヘッダ部の出力
+        $this->output_header($length);
+
+        //  ファイルの出力
+        $this->output_patients($outfilename);
+        unlink($outfilename);
+
+        //-- 最後に終了させるのを忘れない
+        exit;
+    }
+
+    /**
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し、ダウンロードさせる
+     */
+    private function output_patients($filename)
+    {
+        //  ヘッダ出力
+
+        //-- readfile()の前に出力バッファリングを無効化する ※詳細は後述
+        while (ob_get_level()) { ob_end_clean(); }
+
+        //-- 出力
+        readfile($filename);
+    }
+
+    /**
+     * ヘッダ部の出力
+     */
+    private function output_header($length)
+    {
+        $mimeType = 'text/csv';
+
+        //-- Content-Type
+        header('Content-Type: ' . $mimeType);
+
+        //-- ウェブブラウザが独自にMIMEタイプを判断する処理を抑止する
+        header('X-Content-Type-Options: nosniff');
+
+        //-- ダウンロードファイルのサイズ
+        header('Content-Length: ' . $length);
+
+        //-- ダウンロード時のファイル名
+        header('Content-Disposition: attachment; filename="' . $this->RemoteCSV . '"');
+
+        //-- keep-aliveを無効にする
+        header('Connection: close');
+
+    }
+}

--- a/app/Patients.php
+++ b/app/Patients.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace App;
+namespace App;　
+
+
+
 
 use Illuminate\Support\Collection;
 

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -71,9 +71,9 @@
                         </p>
                         </h5>
                     </div>
-                    <div class="container bg-warning" > 
+                    <div class="container bg-primary" > 
                         <h3>
-                            <a  style="color: #ffffff;">検査実施人数(工事中)</a>
+                            <a href={{url('/opendata/get_inspected')}} style="color: #ffffff;">検査実施人数</a>
                         </h3>
                     </div>
                     <div class="container bg-warning" > 

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,4 +17,6 @@ Route::get('/opendata', function () {
     return view('top');
 });
 Route::get('/opendata/get_patients', 'OpendataController@get_patients');
+Route::get('/opendata/get_inspected', 'ToyamaCountsController@get_inspected');
+
 


### PR DESCRIPTION
富山県のオープンデータ(コロナウィルス関連データ（陽性患者属性以外）(CSV))から、検査実施人数を抽出する処理を作成した。
年月日は、結果判明_年月日とした。
なお、2/27分には、2/27以前の分を含んでいる。