### PR TITLE
陰性確認数のデータダウンロードを開発した。

### DIFF
--- a/app/ConfirmNegative.php
+++ b/app/ConfirmNegative.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App;
+use Illuminate\Support\Collection;
+use App\Counts;
+
+class ConfirmNegative extends Counts
+{
+    /**
+     * オリジナルレコードを元に、変換後のデータを作成する。
+     */
+    public function convert()
+    {
+        $this->DstRec =  new Collection();
+
+        foreach($this->OriginalRec as $rec)
+        {
+            $dst_rec = array();
+
+            //  Byte Order Markを削除
+            if(strcmp(preg_replace('/^\xEF\xBB\xBF/', '', $rec[0]), "年月日") == 0) 
+            {
+                continue;
+            }
+            //  年月日
+            array_push($dst_rec, $rec[0]);
+            // 　自治体コード(富山県固定)
+            array_push($dst_rec, "16000");
+            //  都道府県名(富山県固定)
+            array_push($dst_rec, "富山県");
+            //  市区町村名(県発表のため、空白)
+            array_push($dst_rec, "");
+            //  陰性確認_件数
+            array_push($dst_rec, $rec[2]);
+            //  備考
+            array_push($dst_rec, $rec[7]);
+
+            $this->DstRec->push($dst_rec);
+        }
+    }
+    
+	public function headings():array
+	{
+		return [
+            pack('C*',0xEF,0xBB,0xBF).'完了_年月日', 
+            '全国地方公共団体コード',
+            '都道府県名',
+            '市区町村名',
+            '陰性確認_件数',
+            '備考',
+        ];
+	}
+
+}

--- a/app/Http/Controllers/ConfirmNegativeController.php
+++ b/app/Http/Controllers/ConfirmNegativeController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\ConfirmNegative;
+
+
+class ConfirmNegativeController extends Controller
+{
+    protected $RemoteCSV = '16000_toyama_covid19_confirm_negative.csv';
+    protected $LocalCSV = 'toyama_counts.';
+    protected $OpendataPath = 'http://opendata.pref.toyama.jp/files/covid19/20200403/toyama_counts.csv';
+
+    /**
+     * 陽性患者属性以外を富山県オープンデータサイトから取得し、
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し
+     * ダウンロードする。
+     */
+    public function get_confirm_negative()
+    {
+        //  県のオープンデータを取得し、一旦、保存する
+        $csv = file_get_contents($this->OpendataPath); //ファイルの保存先
+        $filename = tempnam ('./', $this->LocalCSV);
+        file_put_contents($filename,$csv);
+
+        //  CSVファイルを読み込み
+        $fp = fopen($filename, 'r');
+        if($fp == FALSE) {
+            throw new Exception('Error: Failed to open file (' . $filename . ')');
+        }
+
+        $ConfirmNegative = new ConfirmNegative();
+        while (($rec = fgetcsv($fp)) != FALSE) {
+            $ConfirmNegative->push($rec);
+        }
+
+        fclose($fp);
+        unlink($filename);
+
+        //  出力用のCSV作成
+        $outfilename = tempnam ('./', $this->LocalCSV);
+        $length = $ConfirmNegative->create_file($outfilename);
+
+        //  ヘッダ部の出力
+        $this->output_header($length);
+
+        //  ファイルの出力
+        $this->output_patients($outfilename);
+        unlink($outfilename);
+
+        //-- 最後に終了させるのを忘れない
+        exit;
+    }
+
+    /**
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し、ダウンロードさせる
+     */
+    private function output_patients($filename)
+    {
+        //  ヘッダ出力
+
+        //-- readfile()の前に出力バッファリングを無効化する ※詳細は後述
+        while (ob_get_level()) { ob_end_clean(); }
+
+        //-- 出力
+        readfile($filename);
+    }
+
+    /**
+     * ヘッダ部の出力
+     */
+    private function output_header($length)
+    {
+        $mimeType = 'text/csv';
+
+        //-- Content-Type
+        header('Content-Type: ' . $mimeType);
+
+        //-- ウェブブラウザが独自にMIMEタイプを判断する処理を抑止する
+        header('X-Content-Type-Options: nosniff');
+
+        //-- ダウンロードファイルのサイズ
+        header('Content-Length: ' . $length);
+
+        //-- ダウンロード時のファイル名
+        header('Content-Disposition: attachment; filename="' . $this->RemoteCSV . '"');
+
+        //-- keep-aliveを無効にする
+        header('Connection: close');
+
+    }
+}

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -81,9 +81,9 @@
                             <a style="color: #ffffff;">検査実施件数(工事中)</a>
                         </h3>
                     </div>
-                    <div class="container bg-warning" > 
+                    <div class="container bg-primary" > 
                         <h3>
-                            <a style="color: #ffffff;">陰性確認数(工事中)</a>
+                            <a href={{url('/opendata/get_confirm_negative')}} style="color: #ffffff;">陰性確認数</a>
                         </h3>
                     </div>
                     <div class="container bg-warning" > 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,5 +18,6 @@ Route::get('/opendata', function () {
 });
 Route::get('/opendata/get_patients', 'OpendataController@get_patients');
 Route::get('/opendata/get_inspected', 'ToyamaCountsController@get_inspected');
+Route::get('/opendata/get_confirm_negative', 'ConfirmNegativeController@get_confirm_negative');
 
 


### PR DESCRIPTION
富山県のオープンデータ(コロナウィルス関連データ（陽性患者属性以外）(CSV))から、陰性確認数を抽出する処理を作成した。
なお、2/27分には、2/27以前の分を含んでいる。

