### PR TITLE
コールセンター相談件数のダウンロード処理を追加した。

### DIFF
--- a/app/CallCenter.php
+++ b/app/CallCenter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App;
+use Illuminate\Support\Collection;
+use App\Counts;
+
+class CallCenter extends Counts
+{
+    public static $GENERAL = 1;
+    public static $RETURN = 2;
+    public static $ALL = 0;
+ 
+    protected $CallCenterMode;
+
+    /**
+     * インスタンス作成時、 モードを指定する
+     * 
+     * @param  $mode    抽出するコールセンターを指定する
+     *                  CallCenter::ALL     全て
+     *                  CallCenter::GENERAL 一般のコールセンター
+     *                  CallCenter::RETURN  帰国者向けのコールセンター
+     */
+    public function __construct($mode)
+    {
+        $this->CallCenterMode = $mode;
+        $this->OriginalRec = new Collection();
+    }
+
+    /**
+     * オリジナルレコードを元に、変換後のデータを作成する。
+     */
+    public function convert()
+    {
+        $this->DstRec =  new Collection();
+
+        foreach($this->OriginalRec as $rec)
+        {
+            $dst_rec = array();
+
+            //  Byte Order Markを削除
+            if(strcmp(preg_replace('/^\xEF\xBB\xBF/', '', $rec[0]), "年月日") == 0) 
+            {
+                continue;
+            }
+            //  年月日
+            array_push($dst_rec, $rec[0]);
+            // 　自治体コード(富山県固定)
+            array_push($dst_rec, "16000");
+            //  都道府県名(富山県固定)
+            array_push($dst_rec, "富山県");
+            //  市区町村名(県発表のため、空白)
+            array_push($dst_rec, "");
+            //  相談件数
+            if($this->CallCenterMode == CallCenter::$ALL) {
+                $gen = is_numeric($rec[4]) ? $rec[4] : 0;
+                $ret = is_numeric($rec[5]) ? $rec[5] : 0;
+                array_push($dst_rec, $gen +  $ret);
+            }
+            if($this->CallCenterMode == CallCenter::$GENERAL) {
+                array_push($dst_rec, $rec[4]);
+            }
+            if($this->CallCenterMode == CallCenter::$RETURN) {
+                array_push($dst_rec, $rec[5]);
+            }
+            
+            //  備考
+            array_push($dst_rec, $rec[7]);
+
+            $this->DstRec->push($dst_rec);
+        }
+    }
+    
+	public function headings():array
+	{
+		return [
+            pack('C*',0xEF,0xBB,0xBF).'完了_年月日', 
+            '全国地方公共団体コード',
+            '都道府県名',
+            '市区町村名',
+            '相談件数',
+            '備考',
+        ];
+	}
+
+}

--- a/app/Http/Controllers/CallCenterController.php
+++ b/app/Http/Controllers/CallCenterController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\CallCenter;
+
+
+class CallCenterController extends Controller
+{
+    protected $RemoteCSV = '16000_toyama_covid19_call_center.csv';
+    protected $LocalCSV = 'toyama_counts.';
+    protected $OpendataPath = 'http://opendata.pref.toyama.jp/files/covid19/20200403/toyama_counts.csv';
+
+    /**
+     * 陽性患者属性以外を富山県オープンデータサイトから取得し、
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し
+     * ダウンロードする。
+     */
+    public function get_call_center(Request $request)
+    {
+        //  県のオープンデータを取得し、一旦、保存する
+        $csv = file_get_contents($this->OpendataPath); //ファイルの保存先
+        $filename = tempnam ('./', $this->LocalCSV);
+        file_put_contents($filename,$csv);
+
+        //  CSVファイルを読み込み
+        $fp = fopen($filename, 'r');
+        if($fp == FALSE) {
+            throw new Exception('Error: Failed to open file (' . $filename . ')');
+        }
+
+        $mode = $request->input('mode');
+        $call_center_param = CallCenter::$ALL;
+
+        if($mode ==  'general') {
+            $call_center_param = CallCenter::$GENERAL;
+            $this->RemoteCSV = '16000_toyama_covid19_general_call_center.csv';
+        } 
+        if($mode ==  'return') {
+            $call_center_param = CallCenter::$RETURN;
+            $this->RemoteCSV = '16000_toyama_covid19_return_call_center.csv';
+        }
+        $CallCenter = new CallCenter($call_center_param);
+        while (($rec = fgetcsv($fp)) != FALSE) {
+            $CallCenter->push($rec);
+        }
+
+        fclose($fp);
+        unlink($filename);
+
+        //  出力用のCSV作成
+        $outfilename = tempnam ('./', $this->LocalCSV);
+        $length = $CallCenter->create_file($outfilename);
+
+        //  ヘッダ部の出力
+        $this->output_header($length);
+
+        //  ファイルの出力
+        $this->output_patients($outfilename);
+        unlink($outfilename);
+
+        //-- 最後に終了させるのを忘れない
+        exit;
+    }
+
+    /**
+     * 新型コロナウイルス感染症対策に関するオープンデータ項目定義書に準拠したCSVを作成し、ダウンロードさせる
+     */
+    private function output_patients($filename)
+    {
+        //  ヘッダ出力
+
+        //-- readfile()の前に出力バッファリングを無効化する ※詳細は後述
+        while (ob_get_level()) { ob_end_clean(); }
+
+        //-- 出力
+        readfile($filename);
+    }
+
+    /**
+     * ヘッダ部の出力
+     */
+    private function output_header($length)
+    {
+        $mimeType = 'text/csv';
+
+        //-- Content-Type
+        header('Content-Type: ' . $mimeType);
+
+        //-- ウェブブラウザが独自にMIMEタイプを判断する処理を抑止する
+        header('X-Content-Type-Options: nosniff');
+
+        //-- ダウンロードファイルのサイズ
+        header('Content-Length: ' . $length);
+
+        //-- ダウンロード時のファイル名
+        header('Content-Disposition: attachment; filename="' . $this->RemoteCSV . '"');
+
+        //-- keep-aliveを無効にする
+        header('Connection: close');
+
+    }
+}

--- a/resources/views/top.blade.php
+++ b/resources/views/top.blade.php
@@ -51,6 +51,9 @@
                         <h3>
                             <a href={{url('/opendata/get_patients')}} style="color: #ffffff;">陽性患者属性情報</a>
                         </h3>
+                        <h6>
+                        <a href={{url('/opendata/get_patients')}} style="color: #ffffff;">{{url('/opendata/get_patients')}}</a>
+                        </h6>
                     </div>
                     <div class="container-fluid" style="margin-top:1rem">
                         <h5>
@@ -64,7 +67,7 @@
                             患者_属性については、現状では「入院中」のみ設定されています。このため、このサイトではデータを設定しておりません(退院済フラグに反映しています)。
                         </p>
                         <p>
-                            富山県においては、入院中/退院済の情報は、属性としては提供される可能性は低いと考えられます。
+                            富山県においては、入院中/退院済の情報は、提供されない見通しです。
                         </p>
                         <p>
                             市区町村名は、富山県オープンデータには「富山市」のみ設定されています。
@@ -75,22 +78,78 @@
                         <h3>
                             <a href={{url('/opendata/get_inspected')}} style="color: #ffffff;">検査実施人数</a>
                         </h3>
+                        <h6>
+                        <a href={{url('/opendata/get_inspected')}} style="color: #ffffff;">{{url('/opendata/get_inspected')}}</a>
+                        </h6>
                     </div>
+                    <h5>
+                    <p>
+                        上のリンクから検査実施人数(新型コロナウイルス感染症対策に関するオープンデータ項目定義書準拠)ダウンロードが可能です。呼び出されたタイミングで、富山県のオープンデータサイトから最新データを取得・データ変換します。
+                    </p>
+                    <p>
+                        【注意事項】
+                    </p>
+                    <p>
+                        先頭カラムの年月日は、富山県の場合「結果判明_年月日」としています。
+                    </p>
+                    </h5>
+                    <div class="container bg-primary" > 
+                        <h3>
+                            <a href={{url('/opendata/get_confirm_negative')}} style="color: #ffffff;">陰性確認数</a>
+                        </h3>
+                        <h6>
+                            <a href={{url('/opendata/get_confirm_negative')}} style="color: #ffffff;">{{url('/opendata/get_confirm_negative')}}</a>
+                        </h6>
+                    </div>
+                    <h5>
+                    <p>
+                        上のリンクから陰性確認数(新型コロナウイルス感染症対策に関するオープンデータ項目定義書準拠)ダウンロードが可能です。呼び出されたタイミングで、富山県のオープンデータサイトから最新データを取得・データ変換します。
+                    </p>
+                    </h5>
+
+                    <div class="container bg-primary" > 
+                    <h3>
+                            <a href={{url('/opendata/get_call_center')}} style="color: #ffffff;">コールセンター相談件数(全件)</a>
+                        </h3>
+                        <h6>
+                            <a href={{url('/opendata/get_call_center')}} style="color: #ffffff;">{{url('/opendata/get_call_center')}}</a>
+                        </h6>
+                        <h3>
+                            <a href={{url('/opendata/get_call_center?mode=general')}} style="color: #ffffff;">コールセンター相談件数(一般相談件数のみ)</a>
+                        </h3>
+                        <h6>
+                            <a href={{url('/opendata/get_call_center?mode=general')}} style="color: #ffffff;">{{url('/opendata/get_call_center?mode=general')}}</a>
+                        </h6>
+                        <h3>
+                            <a href={{url('/opendata/get_call_center?mode=return')}} style="color: #ffffff;">コールセンター相談件数(帰国者相談件数のみ)</a>
+                        </h3>
+                        <h6>
+                            <a href={{url('/opendata/get_call_center?mode=return')}} style="color: #ffffff;">{{url('/opendata/get_call_center?mode=return')}}</a>
+                        </h6>
+                    </div>
+                    <h5>
+                    <p>
+                        上のリンクからコールセンター相談件数(新型コロナウイルス感染症対策に関するオープンデータ項目定義書準拠)ダウンロードが可能です。呼び出されたタイミングで、富山県のオープンデータサイトから最新データを取得・データ変換します。
+                    </p>
+                    <p>
+                        【注意事項】
+                    </p>
+                    <p>
+                        富山県では、一般相談と帰国者相談の二つの相談窓口があります。全件、一般相談及び帰国者相談の件数をダウンロードが可能です。
+                    </p>
+                    </h5>
+
                     <div class="container bg-warning" > 
                         <h3>
                             <a style="color: #ffffff;">検査実施件数(工事中)</a>
                         </h3>
                     </div>
-                    <div class="container bg-primary" > 
-                        <h3>
-                            <a href={{url('/opendata/get_confirm_negative')}} style="color: #ffffff;">陰性確認数</a>
-                        </h3>
-                    </div>
-                    <div class="container bg-warning" > 
-                        <h3>
-                            <a style="color: #ffffff;">コールセンター相談件数(工事中)</a>
-                        </h3>
-                    </div>
+                    <h5>
+                    <p>
+                        富山県では、検査人数は公表されていますが、検査件数の公表はされていません。このデータの提供時期は、未定です。
+                    </p>
+
+
 
                     <div class="container" style="margin-top:3rem"> 
                         <p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,5 +19,4 @@ Route::get('/opendata', function () {
 Route::get('/opendata/get_patients', 'OpendataController@get_patients');
 Route::get('/opendata/get_inspected', 'ToyamaCountsController@get_inspected');
 Route::get('/opendata/get_confirm_negative', 'ConfirmNegativeController@get_confirm_negative');
-
-
+Route::get('/opendata/get_call_center', 'CallCenterController@get_call_center');


### PR DESCRIPTION
一通り開発終了。
一般相談件数、帰国者相談件数及び全件でダウンロードが可能。
ファイル名は、以下のとおり。
全件：16000_toyama_covid19_call_center.csv
一般：16000_toyama_covid19_general_call_center.csv
帰国者：16000_toyama_covid19_return_call_center.csv
